### PR TITLE
Fix double encoding of Firebase Storage URLs

### DIFF
--- a/src/test/firebaseStorage.test.ts
+++ b/src/test/firebaseStorage.test.ts
@@ -36,7 +36,7 @@ describe('Firebase Storage Utilities', () => {
 
     it('should handle complex file paths with folders', () => {
       const gsUrl = 'gs://my-bucket/documents/subfolder/test file.pdf';
-      const expected = 'https://firebasestorage.googleapis.com/v0/b/my-bucket/o/documents%2Fsubfolder%2Ftest%2520file.pdf?alt=media';
+      const expected = 'https://firebasestorage.googleapis.com/v0/b/my-bucket/o/documents%2Fsubfolder%2Ftest%20file.pdf?alt=media';
       
       expect(convertGsUrlToDownloadUrl(gsUrl)).toBe(expected);
     });

--- a/src/utils/firebaseStorage.ts
+++ b/src/utils/firebaseStorage.ts
@@ -27,7 +27,9 @@ export const convertGsUrlToDownloadUrl = (gsUrl: string): string => {
     // Format: gs://bucket-name/path/to/file.pdf
     const url = new URL(gsUrl);
     const bucket = url.hostname;
-    const path = url.pathname.substring(1); // Remove leading slash
+    // URL.pathname is already percent-encoded. Decode before re-encoding to
+    // avoid double encoding characters like spaces.
+    const path = decodeURIComponent(url.pathname).substring(1); // Remove leading slash
     
     // Check for malformed URLs (empty bucket or path)
     if (!bucket || bucket.trim() === '') {


### PR DESCRIPTION
## Summary
- decode gs:// paths before re-encoding to avoid double escaping
- update Firebase Storage tests for new URL format

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-explicit-any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684f0d1be56883309fbadf8cfe43d719